### PR TITLE
Combo Box Alignment Fix

### DIFF
--- a/ValueEditor/ValueEditor.qss
+++ b/ValueEditor/ValueEditor.qss
@@ -61,16 +61,21 @@ QWidget#StringItem > QPushButton {
     background-color: #2A2A2A;
 }
 
-QWidget#ColorItem > ComboBox {
+QWidget#ColorItem > QComboBox {
     margin-left: 0px;
     margin-right: 0px;
 }
 
-QWidget > ComboBox {
-    margin-left: 11px;
-    margin-right: 11px;
+QWidget > QComboBox {
+    margin-left: 10px;
+    margin-right: 10px;
 }
 
-QWidget > ComboBox::drop-down {
-    subcontrol-origin: margin;  
+QWidget > QComboBox::drop-down {
+    subcontrol-origin: margin;
+}
+
+QComboBox QAbstractItemView {
+    margin-left: 10px;
+    margin-right: 10px;
 }

--- a/ValueEditor/ValueEditor.qss
+++ b/ValueEditor/ValueEditor.qss
@@ -66,6 +66,15 @@ QWidget#ColorItem > QComboBox {
     margin-right: 0px;
 }
 
+QWidget#ColorItem > QComboBox::drop-down {
+    subcontrol-origin: margin;
+}
+
+QWidget#ColorItem QAbstractItemView {
+    margin-left: 0px;
+    margin-right: 0px;
+}
+
 QWidget > QComboBox {
     margin-left: 10px;
     margin-right: 10px;

--- a/ValueEditor/ValueEditor_Maya.qss
+++ b/ValueEditor/ValueEditor_Maya.qss
@@ -69,16 +69,21 @@ QWidget#StringItem > QPushButton {
     background-color: #2A2A2A;
 }
 
-QWidget#ColorItem > ComboBox {
+QWidget#ColorItem > QComboBox {
     margin-left: 0px;
     margin-right: 0px;
 }
 
-QWidget > ComboBox {
-    margin-left: 11px;
-    margin-right: 11px;
+QWidget > QComboBox {
+    margin-left: 10px;
+    margin-right: 10px;
 }
 
-QWidget > ComboBox::drop-down {
+QWidget > QComboBox::drop-down {
     subcontrol-origin: margin;  
+}
+
+QComboBox QAbstractItemView {
+    margin-left: 10px;
+    margin-right: 10px;
 }

--- a/ValueEditor/ValueEditor_Maya.qss
+++ b/ValueEditor/ValueEditor_Maya.qss
@@ -74,6 +74,15 @@ QWidget#ColorItem > QComboBox {
     margin-right: 0px;
 }
 
+QWidget#ColorItem > QComboBox::drop-down {
+    subcontrol-origin: margin;
+}
+
+QWidget#ColorItem QAbstractItemView {
+    margin-left: 0px;
+    margin-right: 0px;
+}
+
 QWidget > QComboBox {
     margin-left: 10px;
     margin-right: 10px;


### PR DESCRIPTION
@reality3d @pzion 

Changes: Corrected typos and adjusted ComboBox margins to line up with other widgets in Value Editor.

Test: Yes. Still an issue with the size of the combobox drop down not resizing, but the Value Editor implementation needs to be refactored a bit to get this fixed. Did some research online about the issue and a QListView() needs to be passed to the combo box object. That is a larger task that needs more testing.

Risk: Low, only changes alignment of drop down widgets.